### PR TITLE
Fixed typo In `cos_sim_2d`

### DIFF
--- a/retrieval/wikipedia.py
+++ b/retrieval/wikipedia.py
@@ -20,7 +20,7 @@ def mean_pooling(token_embeddings, mask):
 
 def cos_sim_2d(x, y):
     norm_x = x / np.linalg.norm(x, axis=1, keepdims=True)
-    norm_y = y / np.linalg.norm(x, axis=1, keepdims=True)
+    norm_y = y / np.linalg.norm(y, axis=1, keepdims=True)
     return np.matmul(norm_x, norm_y.T)
 
 


### PR DESCRIPTION
I noticed this, which seems likely to be a bug in `cos_sim_2d(x, y)`.