### PR TITLE
Update documentation to switch to mamba

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,19 @@ Before you begin, you need to install PyTorch and other dependencies.
 git lfs install
 ```
 
-4. Create an environment called OpenChatKit using the `environment.yml` file at the root of this repo.
+4. Install mamba in the `base` environment so it's available in all environments.
 
 ```shell
-conda env create -f environment.yml
+conda install mamba -n base -c conda-forge
 ```
 
-5. Activate the new conda environment.
+5. Create an environment called OpenChatKit using the `environment.yml` file at the root of this repo.
+
+```shell
+mamba env create -f environment.yml 
+```
+
+6. Activate the new conda environment.
 
 ```shell
 conda activate OpenChatKit

--- a/README.md
+++ b/README.md
@@ -32,16 +32,19 @@ In this repo, you'll find code for:
 Before you begin, you need to install PyTorch and other dependencies.
 
 1. Install [Miniconda](https://docs.conda.io/en/latest/miniconda.html) from their website.
-2. Create an environment called OpenChatKit using the `environment.yml` file at the root of this repo.
 
-```shell
-conda env create -f environment.yml
-```
+2. Install [Git LFS](https://git-lfs.com/) from their website.
 
-This repo also uses [Git LFS](https://git-lfs.com/) to manage some files. Install it using the instructions on their site then run:
+3. Install the `git lfs` hooks.
 
 ```shell
 git lfs install
+```
+
+4. Create an environment called OpenChatKit using the `environment.yml` file at the root of this repo.
+
+```shell
+conda env create -f environment.yml
 ```
 
 # Pre-trained Weights

--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ git lfs install
 conda env create -f environment.yml
 ```
 
+5. Activate the new conda environment.
+
+```shell
+conda activate OpenChatKit
+```
+
 # Pre-trained Weights
 
 GPT-NeoXT-Chat-Base-20B is a 20B-parameter variant of GPT-NeoX, fine-tuned on conversational datasets. We are releasing pre-trained weights for this model as [togethercomputer/GPT-NeoXT-Chat-Base-20B](https://huggingface.co/togethercomputer/GPT-NeoXT-Chat-Base-20B) on Huggingface.


### PR DESCRIPTION
Installing the environment can be painfully slow. Some users have
expereienced waits up to 60 minutes! The `mamba` tool seems to be much
faster while maintaining compatibility with regular `conda` commands.

Installing `mamba` itself takes about 30 seconds.

```
time conda install mamba -n base -c conda-forge
...
real    0m29.866s
user    0m20.274s
sys     0m2.779s
```

Installing the entire environment.yml takes about 2.5 minutes.

```
time mamba env create -f environment.yml -n OpenChatKit-Test
...
real    2m22.678s
user    2m20.410s
sys     0m10.147s
```

Normal conda commands appear to work just fine with the resulting
environment and a short training run was successful.

Fixes #16.
