### PR TITLE
Reduce RAM usage and load time

### DIFF
--- a/inference/bot.py
+++ b/inference/bot.py
@@ -20,7 +20,7 @@ class ChatModel:
     def __init__(self, model_name, gpu_id):
         device = torch.device('cuda', gpu_id)
         self._model = AutoModelForCausalLM.from_pretrained(
-            model_name).half()
+            model_name, torch_dtype=torch.float16, device_map="auto").half()
         self._model.to(device)
         self._tokenizer = AutoTokenizer.from_pretrained(model_name)
 


### PR DESCRIPTION
Running the current version of `inference/bot.py` requires ~92 GB of free memory (to load the model) + ~40 GB GPU (after the model has loaded).

This PR reduces the required free RAM to ~11.5 GB.

Also, the current version takes ~3 minutes and 20 seconds to run/load the model (on an A100). This PR reduces that time to ~30 second.

This PR was tested on both an 1x A40 (48GB) and also on an 1x A100 80GB. Both yielded similar stats.