### PR TITLE
Add example notebook and argument for 8-bit-inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ In this repo, you'll find code for:
 
 # Contents
 
+- [Try it out](#try-it-out)
 - [Getting Started](#getting-started)
   * [Requirements](#requirements)
   * [Chatting with Pythia-Chat-Base-7B](#chatting-with-pythia-chat-base-7b)
@@ -28,9 +29,16 @@ In this repo, you'll find code for:
 - [Citing OpenChatKit](#citing-openchatkit)
 - [Acknowledgements](#acknowledgements)
 
+# Try it out
+- [OpenChatKit Feedback App](https://huggingface.co/spaces/togethercomputer/OpenChatKit)
+Feedback helps improve the bot and open-source AI research.
+
+- [Run it on Google Colab](inference/README.md#running-on-google-colab) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/togethercomputer/OpenChatKit/blob/main/inference/example/example.ipynb)
+- Continue reading to run it on your own!
+
 # Getting Started
 
-In this tutorial, you will download Pythia-Chat-Base-7B, an instruction-tuned language model, and run some some inference requests against it using a command-line tool.
+In this tutorial, you will download Pythia-Chat-Base-7B, an instruction-tuned language model, and run some inference requests against it using a command-line tool.
 
 Pythia-Chat-Base-7B is a 7B-parameter fine-tuned variant of Pythia-6.9B-deduped from Eleuther AI. Pre-trained weights for this model are available on Huggingface as [togethercomputer/Pythia-Chat-Base-7B](https://huggingface.co/togethercomputer/Pythia-Chat-Base-7B) under an Apache 2.0 license.
 
@@ -73,7 +81,7 @@ conda activate OpenChatKit
 
 ## Chatting with Pythia-Chat-Base-7B
 
-To help you try the model, [`inference/bot.py`](inference/bot.py) is a simple command-line test harness that provides a shell inferface enabling you to chat with the model. Simply enter text at the prompt and the model replies. The test harness also maintains conversation history to provide the model with context.
+To help you try the model, [`inference/bot.py`](inference/bot.py) is a simple command-line test harness that provides a shell interface enabling you to chat with the model. Simply enter text at the prompt and the model replies. The test harness also maintains conversation history to provide the model with context.
 
 
 Start the bot by calling `bot.py` from the root for the repo.

--- a/docs/GPT-NeoXT-Chat-Base-20B.md
+++ b/docs/GPT-NeoXT-Chat-Base-20B.md
@@ -184,7 +184,7 @@ Hello human.
 
 Commands are prefixed with a `/`, and the `/quit` command exits.
 
-Please see [the inference README](inference/README.md) for more details about arguments, running on multiple/specific GPUs, and running on consumer hardware.
+Please see [the inference README](GPT-NeoXT-Chat-Base-Inference.md) for more details about arguments, running on multiple/specific GPUs, and running on consumer hardware.
 
 # Monitoring
 

--- a/docs/GPT-NeoXT-Chat-Base-Inference.md
+++ b/docs/GPT-NeoXT-Chat-Base-Inference.md
@@ -1,5 +1,4 @@
-# OpenChatKit Inference
-This directory contains code for OpenChatKit's inference.
+# GPT-NeoXT-Chat-Base-20B Inference
 
 ## Contents
 
@@ -8,11 +7,10 @@ This directory contains code for OpenChatKit's inference.
 - [Running on multiple GPUs](#running-on-multiple-gpus)
 - [Running on specific GPUs](#running-on-specific-gpus)
 - [Running on consumer hardware](#running-on-consumer-hardware)
-- [Running on Google Colab](#running-on-google-colab) 
 
 ## Arguments
 - `--gpu-id`: primary GPU device to load inputs onto for inference. Default: `0`
-- `--model`: name/path of the model. Default = `../huggingface_models/Pythia-Chat-Base-7B`
+- `--model`: name/path of the model. Default = `../huggingface_models/GPT-NeoXT-Chat-Base-20B`
 - `--max-tokens`: the maximum number of tokens to generate. Default: `128`
 - `--sample`: indicates whether to sample. Default: `True`
 - `--temperature`: temperature for the LM. Default: `0.6`
@@ -23,15 +21,13 @@ This directory contains code for OpenChatKit's inference.
 - `--load-in-8bit`: load model in 8-bit. Requires `pip install bitsandbytes`. No effect when used with `-g`. 
 
 ## Hardware requirements for inference
-The Pythia-Chat-Base-7B model requires:
+The GPT-NeoXT-Chat-Base-20B model requires at least 41GB of free VRAM. Used VRAM also goes up by ~100-200 MB per prompt. 
 
-- **18 GB of GPU memory for the base model**
+- A **minimum of 80 GB is recommended** 
 
-- **9 GB of GPU memory for the 8-bit quantized model**
+- A **minimum of 48 GB in VRAM is recommended** for fast responses.
 
-Used VRAM also goes up by ~100-200 MB per prompt. 
-
-If you'd like to run inference on a GPU with less VRAM than the size of the model, refer to this section on [running on consumer hardware](#running-on-consumer-hardware).
+If you'd like to run inference on a GPU with <48 GB VRAM, refer to this section on [running on consumer hardware](#running-on-consumer-hardware).
 
 By default, inference uses only CUDA Device 0.
 
@@ -44,7 +40,7 @@ Add the argument
 
 where IDx is the CUDA ID of the device and MAX_VRAM is the amount of VRAM you'd like to allocate to the device.
 
-For example, if you are running this on 4x 8 GB GPUs and want to distribute the model across all devices, add ```-g 0:4 1:4 2:6 3:6```. In this example, the first two devices get loaded to a max of 4 GiB while the other two are loaded with a max of 6 GiB.
+For example, if you are running this on 4x 48 GB GPUs and want to distribute the model across all devices, add ```-g 0:10 1:12 2:12 3:12 4:12```. In this example, the first device gets loaded to a max of 10 GiB while the others are loaded with a max of 12 GiB.
 
 How it works: The model fills up the max available VRAM on the first device passed and then overflows into the next until the whole model is loaded.
 
@@ -65,9 +61,9 @@ Also, if needed, add the argument `--gpu-id ID` where ID is the CUDA ID of the d
 
 
 ## Running on consumer hardware
-If you have multiple GPUs [the steps mentioned in this section on running on multiple GPUs](#running-on-multiple-gpus) still apply, unless, any of these apply:
-- Running on just 1x GPU with VRAM < size of the model,
-- Less combined VRAM across multiple GPUs than the size of the model,
+If you have multiple GPUs, each <48 GB VRAM, [the steps mentioned in this section on running on multiple GPUs](#running-on-multiple-gpus) still apply, unless, any of these apply:
+- Running on just 1x GPU with <48 GB VRAM,
+- <48 GB VRAM combined across multiple GPUs
 - Running into Out-Of-Memory (OOM) issues
 
 In which case, add the flag `-r CPU_RAM` where CPU_RAM is the maximum amount of RAM you'd like to allocate to loading model. Note: This significantly reduces inference speeds. 
@@ -76,15 +72,8 @@ The model will load without specifying `-r`, however, it is not recommended beca
 
 If the total VRAM + CPU_RAM < the size of the model in GiB, the rest of the model will be offloaded to a folder "offload" at the root of the directory. Note: This significantly reduces inference speeds.
 
-- Example: `-g 0:3 -r 4` will first load up to 3 GiB of the model into the CUDA device 0, then load up to 4 GiB into RAM, and load the rest into the "offload" directory.
+- Example: `-g 0:12 -r 20` will first load up to 12 GiB of the model into the CUDA device 0, then load up to 20 GiB into RAM, and load the rest into the "offload" directory.
 
 How it works: 
 - https://github.com/huggingface/blog/blob/main/accelerate-large-models.md
 - https://www.youtube.com/embed/MWCSGj9jEAo
-
-## Running on Google Colab
-[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/togethercomputer/OpenChatKit/blob/main/inference/example/example.ipynb)
-
-In the [example notebook](example/example.ipynb), you will find code to run the Pythia-Chat-Base-7B 8-bit quantized model. This is recommended for the free version of Colab. If you'd like to disable quantization, simple remove the `--load-in-8bit` flag from the last cell.
-
-Or, simple click on the "Open In Colab" badge to run the example notebook.

--- a/environment.yml
+++ b/environment.yml
@@ -24,6 +24,6 @@ dependencies:
       - datasets==2.10.1
       - loguru==0.6.0
       - netifaces==0.11.0
-      - transformers==4.21.1
+      - transformers==4.27.4
       - wandb==0.13.10
       - zstandard==0.20.0

--- a/inference/example.ipynb
+++ b/inference/example.ipynb
@@ -1,0 +1,163 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "provenance": [],
+      "authorship_tag": "ABX9TyMm6Jtb/FirjPQByRiT6TFm",
+      "include_colab_link": true
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    },
+    "accelerator": "GPU",
+    "gpuClass": "standard"
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "view-in-github",
+        "colab_type": "text"
+      },
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/togethercomputer/OpenChatKit/blob/main/inference/example.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# OpenChatKit"
+      ],
+      "metadata": {
+        "id": "sLrKqm0BULlD"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### Check GPU availability"
+      ],
+      "metadata": {
+        "id": "eZsgPnayURrc"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!nvidia-smi"
+      ],
+      "metadata": {
+        "id": "qy_ENUlFgG4a"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### Install conda"
+      ],
+      "metadata": {
+        "id": "0gy7ssnoT_SI"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && chmod +x Miniconda3-latest-Linux-x86_64.sh && ./Miniconda3-latest-Linux-x86_64.sh -b -f -p /usr/local"
+      ],
+      "metadata": {
+        "id": "11MMVFkAKtyg"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### Setting up conda environment"
+      ],
+      "metadata": {
+        "id": "CD7yF4rvT3Y8"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!conda install mamba -n base -c conda-forge -y"
+      ],
+      "metadata": {
+        "id": "-W6PrOSILQoc"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Expect the next step to take a while"
+      ],
+      "metadata": {
+        "id": "rWzDhB5rTrrT"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!git clone https://github.com/togethercomputer/OpenChatKit.git && cd OpenChatKit && mamba env create -f environment.yml"
+      ],
+      "metadata": {
+        "id": "hC8ob6kuLSn2"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!source activate OpenChatKit && pip install bitsandbytes"
+      ],
+      "metadata": {
+        "id": "T_K3hXCVz7I1"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### Loading and running the model"
+      ],
+      "metadata": {
+        "id": "jOKRM0VVUjwk"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "\n",
+        "The model will be downloaded the first time. Remove `--load-in-8bit` to disable loading model in 8-bit.\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "psFgkD69Upu3"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!source activate OpenChatKit && python OpenChatKit/inference/bot.py --model togethercomputer/Pythia-Chat-Base-7B --load-in-8bit"
+      ],
+      "metadata": {
+        "id": "9hvg2CLSZ2Kd"
+      },
+      "execution_count": null,
+      "outputs": []
+    }
+  ]
+}

--- a/inference/example/example.ipynb
+++ b/inference/example/example.ipynb
@@ -25,7 +25,7 @@
         "colab_type": "text"
       },
       "source": [
-        "<a href=\"https://colab.research.google.com/github/togethercomputer/OpenChatKit/blob/main/inference/example.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+        "<a href=\"https://colab.research.google.com/github/togethercomputer/OpenChatKit/blob/main/inference/example/example.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
       ]
     },
     {


### PR DESCRIPTION
This PR:
- Adds the argument `--load-in-8bit` for inference
- Adds an example Colab notebook that can run `bot.py` inference (quantized) on a free account. Would have crashed after 5 prompts without quantizing. The user has the option to remove the argument if running on a non-free account.
- Update `transformers==4.21.1` to `transformers==4.27.4` because:
  * It adds support for 8-bit quantization to the model class
  * It shows a progress bar when loading the model which can be helpful for consumer hardware
- Update documentation to reflect recent changes (new model and example notebook)

Note: the links to 'Open in Colab' have been modified to how it should look after the merge. For testing purposes, use [this branch](https://github.com/orangetin/OpenChatKit/blob/colab-example/inference/example/example.ipynb) with the original links instead. [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/orangetin/OpenChatKit/blob/colab-example/inference/example/example.ipynb)