### PR TITLE
Convert max_tokens argument to int before passing into inference.

### DIFF
--- a/inference/bot.py
+++ b/inference/bot.py
@@ -114,7 +114,7 @@ class OpenChatKitShell(cmd.Cmd):
         super().__init__()
         self._gpu_id = int(gpu_id)
         self._model_name_or_path = model_name_or_path
-        self._max_tokens = max_tokens
+        self._max_tokens = int(max_tokens)
         self._sample = sample
         self._temperature = temperature
         self._top_k = top_k

--- a/inference/bot.py
+++ b/inference/bot.py
@@ -114,7 +114,7 @@ class OpenChatKitShell(cmd.Cmd):
         super().__init__()
         self._gpu_id = gpu_id
         self._model_name_or_path = model_name_or_path
-        self._max_tokens = int(max_tokens)
+        self._max_tokens = max_tokens
         self._sample = sample
         self._temperature = temperature
         self._top_k = top_k


### PR DESCRIPTION
Otherwise, a TypeError is generated in transformers/generation/utils.py

Traceback (most recent call last):
  File "/home/pwood/src/ai/OpenChatKit/inference/bot.py", line 285, in <module>
    main()
  File "/home/pwood/src/ai/OpenChatKit/inference/bot.py", line 281, in main
    ).cmdloop()
  File "/usr/lib/python3.10/cmd.py", line 138, in cmdloop
    stop = self.onecmd(line)
  File "/usr/lib/python3.10/cmd.py", line 217, in onecmd
    return func(arg)
  File "/home/pwood/src/ai/OpenChatKit/inference/bot.py", line 150, in do_say
    output = self._model.do_inference(
  File "/home/pwood/src/ai/OpenChatKit/inference/bot.py", line 92, in do_inference
    outputs = self._model.generate(
  File "/home/pwood/.local/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 115, in decorate_context
    return func(*args, **kwargs)
  File "/home/pwood/.local/lib/python3.10/site-packages/transformers/generation/utils.py", line 1320, in generate
    generation_config.max_length = generation_config.max_new_tokens + input_ids_seq_length
TypeError: can only concatenate str (not "int") to str