### PR TITLE
Fix AttributeError: 'GPTNeoXForCausalLM' object has no attribute 'ena…

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -24,6 +24,6 @@ dependencies:
       - datasets==2.10.1
       - loguru==0.6.0
       - netifaces==0.11.0
-      - transformers==4.21.1
+      - transformers==4.27.1
       - wandb==0.13.10
       - zstandard==0.20.0


### PR DESCRIPTION
…ble_input_require_grads'

*Error:*
```bash
(trainer) kristijan@aiweiss-1:~/trainer/OpenChatKit$ python training/lora/redpajama-incite-chat-3b.py

===================================BUG REPORT===================================
Welcome to bitsandbytes. For bug reports, please submit your error trace to: https://github.com/TimDettmers/bitsandbytes/issues
================================================================================
CUDA SETUP: CUDA runtime path found: /home/kristijan/.micromamba/envs/trainer/lib/libcudart.so
CUDA SETUP: Highest compute capability among GPUs detected: 7.5
CUDA SETUP: Detected CUDA version 116
CUDA SETUP: Loading binary /home/kristijan/.micromamba/envs/trainer/lib/python3.10/site-packages/bitsandbytes/libbitsandbytes_cuda116.so...
Traceback (most recent call last):
  File "/home/kristijan/trainer/OpenChatKit/training/lora/redpajama-incite-chat-3b.py", line 34, in <module>
    model.enable_input_require_grads()
  File "/home/kristijan/.micromamba/envs/trainer/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1269, in __getattr__
    raise AttributeError("'{}' object has no attribute '{}'".format(
AttributeError: 'GPTNeoXForCausalLM' object has no attribute 'enable_input_require_grads'
```

*Fix:*
Update tranformers from 4.21.1 => 4.27.1

*Reference:*
4.21.1
https://github.com/huggingface/transformers/blob/v4.22.1/src/transformers/modeling_utils.py
4.27.1
https://github.com/huggingface/transformers/blob/v4.27.1/src/transformers/modeling_utils.py#L1150