### PR TITLE
Fastparquet version req is causing issues

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - cudatoolkit=11.6.0
   - cupy=10.4.0
   - faiss-gpu=1.7.2
-  - fastparquet=0.5.0
+  - fastparquet
   - nccl=2.12.12.1
   - pip=22.3.1
   - pyarrow=8.0.0


### PR DESCRIPTION
Environment fails to build because of fastparquet's strict versioning requirements