### PR TITLE
Change RotaryEmbedding to GPTNeoXRotaryEmbedding for Transformers 4.31.0

### DIFF
--- a/training/modules/hf_gptneox_modules.py
+++ b/training/modules/hf_gptneox_modules.py
@@ -13,7 +13,7 @@ from transformers.models.gpt_neox.modeling_gpt_neox import GPTNeoXMLP
 from transformers.models.gpt_neox.modeling_gpt_neox import GPTNeoXLayer as _GPTNeoXBlock
 from transformers.models.gpt_neox.modeling_gpt_neox import GPTNeoXModel as _GPTNeoXModel
 from transformers.models.gpt_neox.configuration_gpt_neox import GPTNeoXConfig as GPTConfig
-from transformers.models.gpt_neox.modeling_gpt_neox import RotaryEmbedding
+from transformers.models.gpt_neox.modeling_gpt_neox import GPTNeoXRotaryEmbedding
 
 
 try:
@@ -111,7 +111,7 @@ class GPTNeoXAttention(_GPTNeoXAttention):
             ),
         )
         self.register_buffer("masked_bias", torch.tensor(-1e9))
-        self.rotary_emb = RotaryEmbedding(
+        self.rotary_emb = GPTNeoXRotaryEmbedding(
             self.rotary_ndims, config.max_position_embeddings, base=config.rotary_emb_base
         )
         self.register_buffer(


### PR DESCRIPTION
Addresses Issue #167, caused by renamed classes in Transformers 4.31.0.

This pull request updates the required RotaryEmbedding class for GPTNeoX to GPTNeoXRotaryEmbeedding within modules/hf_gptneox_modules.py to update to transformers==4.31.0.